### PR TITLE
refactor(Rate): 動態計算 min-width 避免星星會「換行」

### DIFF
--- a/src/components/Rate/Rate.jsx
+++ b/src/components/Rate/Rate.jsx
@@ -39,6 +39,8 @@ Rate.propTypes = {
   firstColor: string,
   /** 符號的間距 */
   gutter: number,
+  /** 是否不換行 */
+  nowrap: bool,
   /** 失去焦點時的 callback */
   onBlur: func,
   /** 選擇時的 callback */
@@ -71,6 +73,7 @@ Rate.defaultProps = {
   disabled: false,
   firstColor: '#ffb940',
   gutter: 8,
+  nowrap: true,
   secondColor: 'rgba(0, 0, 0, 0.25)',
   size: 36,
 };

--- a/src/components/Rate/Rate.style.jsx
+++ b/src/components/Rate/Rate.style.jsx
@@ -16,6 +16,8 @@ export const StyledRateButton = styled(({
     ${mixinSecondColor}
     ${mixinSize}
 
+    min-width: ${({ gutter, size, count }) => (size * count) + (gutter * (count - 1))}px;
+
     .ant-rate-star-half .ant-rate-star-first, .ant-rate-star-full .ant-rate-star-second {
       color: inherit;
     }

--- a/src/components/Rate/Rate.style.jsx
+++ b/src/components/Rate/Rate.style.jsx
@@ -7,7 +7,7 @@ import {
 } from './utils/mixinCSS/mixinCSS';
 
 export const StyledRateButton = styled(({
-  firstColor, gutter, secondColor, size, ...rest
+  firstColor, gutter, nowrap, secondColor, size, ...rest
 }) => <Rate {...rest} />)`
   &.ant-rate {
     ${mixinFirstColor}
@@ -16,7 +16,7 @@ export const StyledRateButton = styled(({
     ${mixinSecondColor}
     ${mixinSize}
 
-    min-width: ${({ gutter, size, count }) => (size * count) + (gutter * (count - 1))}px;
+    ${({ nowrap }) => nowrap ? 'white-space: nowrap' : ''};
 
     .ant-rate-star-half .ant-rate-star-first, .ant-rate-star-full .ant-rate-star-second {
       color: inherit;

--- a/stories/Rate.stories.js
+++ b/stories/Rate.stories.js
@@ -17,6 +17,7 @@ export const Basic = () => (
     count={number('count', 5)}
     firstColor={color('firstColor', '#ffb940')}
     gutter={number('gutter', 8)}
+    nowrap={boolean('nowrap', false)}
     onBlur={action('onBlur')}
     onChange={action('onChange')}
     onFocus={action('onFocus')}


### PR DESCRIPTION
## Before

> <img width="961" alt="Screen Shot 2020-01-21 at 1 20 39 PM" src="https://user-images.githubusercontent.com/12410942/72777836-f2198e00-3c51-11ea-97b6-a229b1eb3315.png">
> ▲ 沒有設定 `min-width`，在排版中一旦被擠壓到，星星就會「換行」

## After

> <img width="1009" alt="Screen Shot 2020-01-21 at 1 24 54 PM" src="https://user-images.githubusercontent.com/12410942/72777837-f2b22480-3c51-11ea-8c49-dffc13741877.png">
> ▲ 有了計算出的 `min-witdh: 212px`，就算被擠壓到也不會換行

> <img width="1051" alt="Screen Shot 2020-01-21 at 1 25 47 PM" src="https://user-images.githubusercontent.com/12410942/72777838-f2b22480-3c51-11ea-8953-0cd61605faa4.png">
> ▲ 就算設定 `count=10` 也會計算出正確的 `min-width`（36*10+8*9=432px）
